### PR TITLE
fix-delay-3blocks

### DIFF
--- a/reporter/block_handler.go
+++ b/reporter/block_handler.go
@@ -60,7 +60,7 @@ func (r *Reporter) blockEventHandler() {
 
 // handleConnectedBlocks handles connected blocks from the BTC client.
 func (r *Reporter) handleConnectedBlocks(event *types.BlockEvent) error {
-	// After delay three blocks, we hope the connected block is on the best chain, otherwise restart bootstrap.
+	// After delay three blocks, hope the connected block is on the best chain, otherwise restart bootstrap.
 	// It is just to reduce branching on Lorenzo side.
 	{
 		ib, _, err := r.btcClient.GetBlockByHeight(uint64(event.Height))
@@ -70,7 +70,7 @@ func (r *Reporter) handleConnectedBlocks(event *types.BlockEvent) error {
 		eventBlockHash := event.Header.BlockHash()
 		ibBlockHash := ib.BlockHash()
 		if !eventBlockHash.IsEqual(&ibBlockHash) {
-			return fmt.Errorf("connected block[%s] isn't one the best chain", eventBlockHash.String())
+			return fmt.Errorf("connected block[%s] isn't on the best chain", eventBlockHash.String())
 		}
 	}
 


### PR DESCRIPTION
- Make sure ConnectedBlocks is on the best chain when it's handled. It is just to reduce branching on Lorenzo side but not 100%.
- adjust blockEvent check delay sleep interval time from 10 minutes to 1 minute.